### PR TITLE
fix: accepting more than just uuids for attribute ids

### DIFF
--- a/packages/validators/src/actions/tasks.ts
+++ b/packages/validators/src/actions/tasks.ts
@@ -23,7 +23,7 @@ export const tasksCreateTaskSchema = z.object({
   attributes: z
     .record(
       z.string().describe("The id of the attribute"),
-      z.string().describe("The value of the attribute")
+      z.string().describe("The value of the attribute"),
     )
     .optional(),
 });
@@ -45,7 +45,7 @@ export const tasksModifyTaskSchema = z.object({
   attributes: z
     .record(
       z.string().describe("The id of the attribute"),
-      z.string().describe("The value of the attribute")
+      z.string().describe("The value of the attribute"),
     )
     .optional(),
 });

--- a/packages/validators/src/actions/tasks.ts
+++ b/packages/validators/src/actions/tasks.ts
@@ -22,8 +22,8 @@ export const tasksCreateTaskSchema = z.object({
     .describe("The due date of the task. Must be in ISO 8601 format."),
   attributes: z
     .record(
-      z.string().uuid().describe("The id of the attribute"),
-      z.string().describe("The value of the attribute"),
+      z.string().describe("The id of the attribute"),
+      z.string().describe("The value of the attribute")
     )
     .optional(),
 });
@@ -44,8 +44,8 @@ export const tasksModifyTaskSchema = z.object({
     .describe("The due date of the task. Must be in ISO 8601 format."),
   attributes: z
     .record(
-      z.string().uuid().describe("The id of the attribute"),
-      z.string().describe("The value of the attribute"),
+      z.string().describe("The id of the attribute"),
+      z.string().describe("The value of the attribute")
     )
     .optional(),
 });


### PR DESCRIPTION
I assumed that attribute ids would be uuids, but for linear priorities, integers are used. Being a UUID is not enforced at all, so 🤷‍♂️